### PR TITLE
Add implementation of `Select()`

### DIFF
--- a/src/Mocks/MockDistribution.cs
+++ b/src/Mocks/MockDistribution.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace RandN
+{
+    public class MockDistribution<T> : IDistribution<T>
+    {
+        public MockDistribution(T item, Boolean success = true)
+        {
+            Item = item;
+            Success = success;
+        }
+
+        public T Item { get; }
+
+        public Boolean Success { get; }
+
+        public T Sample<TRng>(TRng rng) where TRng : notnull, IRng
+        {
+            if (!Success)
+            {
+                throw new InvalidOperationException(
+                    "You cannot sample from a distribution that has been set up to fail.");
+            }
+
+            return Item;
+        }
+
+        public Boolean TrySample<TRng>(TRng rng, out T result) where TRng : notnull, IRng
+        {
+            result = Item;
+            return Success;
+        }
+    }
+}

--- a/src/RandN/Extensions/DistributionExtensions.cs
+++ b/src/RandN/Extensions/DistributionExtensions.cs
@@ -29,7 +29,7 @@ namespace RandN.Extensions
             Func<TSource, TResult> selector) =>
             new SelectDistribution<TSource, TResult>(distribution, selector);
 
-        private class SelectDistribution<TSource, TResult> : IDistribution<TResult>
+        private sealed class SelectDistribution<TSource, TResult> : IDistribution<TResult>
         {
             private readonly IDistribution<TSource> _distribution;
             private readonly Func<TSource, TResult> _selector;

--- a/src/RandN/Extensions/DistributionExtensions.cs
+++ b/src/RandN/Extensions/DistributionExtensions.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace RandN.Extensions
+{
+    /// <summary>
+    /// Contains extension methods for the <see cref="IDistribution{TResult}"/> interface.
+    /// </summary>
+    public static class DistributionExtensions
+    {
+        /// <summary>
+        /// Transforms a distribution by mapping its values using the selector provided.
+        /// This method implements the "map" operator from functional programming principles.
+        /// </summary>
+        /// <example>
+        /// This method enables use of LINQ query syntax over <see cref="IDistribution{TResult}"/>. For example:
+        /// <code>
+        /// IDistribution&lt;int&gt; evenNumbersDistribution =
+        ///     from i in Uniform.NewInclusive(0, 5)
+        ///     select i * 2;
+        /// </code>
+        /// </example>
+        /// <typeparam name="TSource">The generic type of the input distribution.</typeparam>
+        /// <typeparam name="TResult">The generic type of the output distribution.</typeparam>
+        /// <param name="distribution">The distribution to be transformed.</param>
+        /// <param name="selector">The projection to be applied to values from the distribution.</param>
+        public static IDistribution<TResult> Select<TSource, TResult>(
+            this IDistribution<TSource> distribution,
+            Func<TSource, TResult> selector) =>
+            new SelectDistribution<TSource, TResult>(distribution, selector);
+
+        private class SelectDistribution<TSource, TResult> : IDistribution<TResult>
+        {
+            private readonly IDistribution<TSource> _distribution;
+            private readonly Func<TSource, TResult> _selector;
+
+            public SelectDistribution(IDistribution<TSource> distribution, Func<TSource, TResult> selector)
+            {
+                _distribution = distribution;
+                _selector = selector;
+            }
+
+            public TResult Sample<TRng>(TRng rng) where TRng : notnull, IRng
+            {
+                var sample = _distribution.Sample(rng);
+                return _selector(sample);
+            }
+
+            public Boolean TrySample<TRng>(TRng rng, out TResult result) where TRng : notnull, IRng
+            {
+                if (_distribution.TrySample(rng, out var sample))
+                {
+                    result = _selector(sample);
+                    return true;
+                }
+                else
+                {
+                    result = default;
+                    return false;
+                }
+            }
+        }
+    }
+}

--- a/src/RandN/Extensions/DistributionExtensions.cs
+++ b/src/RandN/Extensions/DistributionExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace RandN.Extensions
 {
@@ -45,7 +46,7 @@ namespace RandN.Extensions
                 return _selector(sample);
             }
 
-            public Boolean TrySample<TRng>(TRng rng, out TResult result) where TRng : notnull, IRng
+            public Boolean TrySample<TRng>(TRng rng, [MaybeNullWhen(false)] out TResult result) where TRng : notnull, IRng
             {
                 if (_distribution.TrySample(rng, out var sample))
                 {

--- a/src/Tests/Extensions/DistributionExtensionsTests.cs
+++ b/src/Tests/Extensions/DistributionExtensionsTests.cs
@@ -1,0 +1,67 @@
+using System;
+using Xunit;
+
+namespace RandN.Extensions
+{
+    public class DistributionExtensionsTests
+    {
+        [Theory]
+        [InlineData("", 0)]
+        [InlineData("A", 1)]
+        [InlineData("ABCDEF", 6)]
+        public void Sample(String inputSample, Int32 expectedOutputSample)
+        {
+            var inputDistribution = new MockDistribution<String>(inputSample);
+
+            var outputDistribution = inputDistribution.Select(x => x.Length);
+
+            // Use a throwing RNG to check that sampling from the distribution
+            // does not update the state of the RNG directly.
+            var rng = new ThrowingRng();
+
+            var sampleFromOutputDistribution = outputDistribution.Sample(rng);
+
+            Assert.Equal(expectedOutputSample, sampleFromOutputDistribution);
+        }
+
+        [Theory]
+        [InlineData(null, false, 0, false)]
+        [InlineData("ABC", false, 0, false)] // If sampling fails, the result from the input distribution should be ignored.
+        [InlineData("", true, 0, true)]
+        [InlineData("A", true, 1, true)]
+        [InlineData("ABCDEF", true, 6, true)]
+        public void TrySample(
+            String inputResult,
+            Boolean inputSuccess,
+            Int32 expectedOutputResult,
+            Boolean expectedOutputSuccess)
+        {
+            var inputDistribution = new MockDistribution<String>(inputResult, inputSuccess);
+
+            var outputDistribution = inputDistribution.Select(x => x.Length);
+
+            // Use a throwing RNG to check that sampling from the distribution
+            // does not update the state of the RNG directly.
+            var rng = new ThrowingRng();
+
+            Assert.Equal(expectedOutputSuccess, outputDistribution.TrySample(rng, out var result));
+            Assert.Equal(expectedOutputResult, result);
+        }
+
+        [Fact]
+        public void SampleUsingQuerySyntax()
+        {
+            var inputDistribution = new MockDistribution<String>("ABCDEF");
+
+            var outputDistribution =
+                from x in inputDistribution
+                select x.Length;
+
+            // Use a throwing RNG to check that sampling from the distribution
+            // does not update the state of the RNG directly.
+            var rng = new ThrowingRng();
+
+            Assert.Equal(6, outputDistribution.Sample(rng));
+        }
+    }
+}


### PR DESCRIPTION
PR for https://github.com/ociaw/RandN/issues/11.

I decided to split this up even further, and just add support for `Select()` in this PR.

I've added a `MockDistribution`. This is quite similar to the `Singleton` that I added in the previous PR, but it allows you to control the behaviour of `Sample` and `TrySample`. I think this is a sensible way to test the behaviour of `Select` because we only care about how it maps the values from the underlying distribution.

There's a test with the comment `If sampling fails, the result from the input distribution should be ignored.`. This seems like the most sensible behaviour in this situation, because I imagine most underlying distributions will return `null` in the failure case and so the `selector` function is possibly not suitable to be applied. However, returning `default` in that case is giving me a compile warning of a possible null reference assignment. What do you think is the best way to deal with this? Would it be true to say that if `TrySample` returns `false` that the consumer shouldn't be reading the value of `result`?