### PR TITLE
Adding a ShuffleInPlace that takes in a Span

### DIFF
--- a/src/Benchmarks/Extensions.cs
+++ b/src/Benchmarks/Extensions.cs
@@ -1,30 +1,41 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using BenchmarkDotNet.Attributes;
 
 namespace RandN.Benchmarks;
 
+//[SimpleJob(BenchmarkDotNet.Jobs.RuntimeMoniker.Net48)]
+//[SimpleJob(BenchmarkDotNet.Jobs.RuntimeMoniker.Net60)]
+//[SimpleJob(BenchmarkDotNet.Jobs.RuntimeMoniker.Net80)]
 public class Extensions
 {
     public const Int32 Iterations = 16384;
 
     private readonly StepRng _rng;
-    private readonly List<Int32> _list;
+    private readonly Int32[] _array;
 
     public Extensions()
     {
         _rng = new StepRng(0);
-        _list = new List<Int32>
-        {
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-            11, 12, 13, 14, 15, 16, 17, 18, 19, 20
-        };
+        _array = Enumerable.Range(1, 100).ToArray();
     }
 
     [Benchmark]
     public void ShuffleList()
     {
-        var list = new List<Int32>(_list);
-        _rng.ShuffleInPlace(list);
+        var list = new List<Int32>(_array);
+        for (Int32 i = 0; i < Iterations; i++)
+            _rng.ShuffleInPlace(list);
+    }
+
+
+    [Benchmark]
+    public void ShuffleArray()
+    {
+        var array = new Int32[_array.Length];
+        Array.Copy(_array, array, array.Length);
+        for (Int32 i = 0; i < Iterations; i++)
+            _rng.ShuffleInPlace(array);
     }
 }

--- a/src/RandN/RngExtensions.cs
+++ b/src/RandN/RngExtensions.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using RandN.Distributions;
 
 namespace RandN;
@@ -7,8 +9,7 @@ namespace RandN;
 /// <summary>
 /// Various extension methods to simplify use of RNGs.
 /// </summary>
-public static class RngExtensions
-{
+public static class RngExtensions {
     /// <summary>
     /// Shuffles a list using the in-place Fisher-Yates shuffling algorithm.
     /// </summary>
@@ -17,14 +18,44 @@ public static class RngExtensions
     public static void ShuffleInPlace<TRng, T>(this TRng rng, IList<T> list)
         where TRng : notnull, IRng
     {
-        // Fisher-Yates shuffle
-        for (Int32 i = list.Count - 1; i >= 1; i--)
+        if (list.GetType() == typeof(T[]))
         {
+            ShuffleInPlace(rng, Unsafe.As<T[]>(list).AsSpan());
+            return;
+        }
+#if NET5_0_OR_GREATER
+        else if (list.GetType() == typeof(List<T>))
+        {
+            ShuffleInPlace(rng, CollectionsMarshal.AsSpan(Unsafe.As<List<T>>(list)));
+            return;
+        }
+#endif
+        // Fisher-Yates shuffle
+        for (Int32 i = list.Count - 1; i >= 1; i--) {
             var dist = Uniform.NewInclusive(0, i);
             var swapIndex = dist.Sample(rng);
             T temp = list[swapIndex];
             list[swapIndex] = list[i];
             list[i] = temp;
+        }
+    }
+
+    /// <summary>
+    /// Shuffles a span using the in-place Fisher-Yates shuffling algorithm.
+    /// </summary>
+    /// <param name="rng">The RNG used to shuffle the list.</param>
+    /// <param name="span">The span to be shuffled.</param>
+    public static void ShuffleInPlace<TRng, T>(this TRng rng, Span<T> span)
+        where TRng : notnull, IRng
+    {
+        ref var first = ref MemoryMarshal.GetReference(span); ;
+        // Fisher-Yates shuffle
+        for (Int32 i = span.Length - 1; i >= 1; i--) {
+            var dist = Uniform.NewInclusive(0, i);
+            var swapIndex = dist.Sample(rng);
+            ref var right = ref Unsafe.Add(ref first, i);
+            ref var left = ref Unsafe.Add(ref first, swapIndex);
+            (right, left) = (left, right);
         }
     }
 
@@ -36,8 +67,7 @@ public static class RngExtensions
     /// <returns>A new <typeparamref name="TRng"/> instance.</returns>
     public static TRng Create<TRng, TSeed, TSeedingRng>(this IReproducibleRngFactory<TRng, TSeed> factory, TSeedingRng seedingRng)
         where TRng : notnull, IRng
-        where TSeedingRng : notnull, IRng
-    {
+        where TSeedingRng : notnull, IRng {
         var seed = factory.CreateSeed(seedingRng);
         return factory.Create(seed);
     }

--- a/src/Tests/RngExtensionTests.cs
+++ b/src/Tests/RngExtensionTests.cs
@@ -12,8 +12,18 @@ public sealed class RngExtensionTests
         var list = new List<Int32> { 1, 2, 3, 4, 5, 6, 7 };
         var rng = new StepRng(0) { Increment = 0 };
         rng.ShuffleInPlace(list);
-        Assert.Equal(new[] { 2, 3, 4, 5, 6, 7, 1 }, list);
+        var expectedOrder = new[] { 2, 3, 4, 5, 6, 7, 1 };
+        Assert.Equal(expectedOrder, list);
 
-        Assert.Throws<ArgumentNullException>(() => rng.ShuffleInPlace<StepRng, Int32>(null!));
+        Span<Int32> span = stackalloc Int32[] { 1, 2, 3, 4, 5, 6, 7 };
+        rng.ShuffleInPlace(span);
+        Assert.True(span.SequenceEqual(expectedOrder));
+
+        Assert.Throws<ArgumentNullException>(() => rng.ShuffleInPlace(default(IList<Int32>)!));
+
+        // Doesn't throw with empty input
+        rng.ShuffleInPlace(Array.Empty<Int32>());
+        rng.ShuffleInPlace(new List<Int32>());
+        rng.ShuffleInPlace(Span<Int32>.Empty);
     }
 }


### PR DESCRIPTION
Just adding an overload to ShuffleInPlace for Spans and forwarding to it when possible from the IList<T> version. I saw fairly significant performance improvements when benchmarking it with 1000 ints on my system:

Before:
| Method       | Job                | Runtime            | Mean      | Error    | StdDev   |
|------------- |------------------- |------------------- |----------:|---------:|---------:|
| ShuffleList  | .NET 6.0           | .NET 6.0           | 218.76 ms | 2.931 ms | 2.448 ms |
| ShuffleArray | .NET 6.0           | .NET 6.0           | 257.76 ms | 1.906 ms | 1.783 ms |
| ShuffleList  | .NET 8.0           | .NET 8.0           |  62.22 ms | 1.119 ms | 1.046 ms |
| ShuffleArray | .NET 8.0           | .NET 8.0           | 184.37 ms | 2.613 ms | 2.182 ms |
| ShuffleList  | .NET Framework 4.8 | .NET Framework 4.8 | 260.43 ms | 5.103 ms | 5.877 ms |
| ShuffleArray | .NET Framework 4.8 | .NET Framework 4.8 | 260.39 ms | 2.187 ms | 2.046 ms |

After:
| Method       | Job                | Runtime            | Mean      | Error    | StdDev   |
|------------- |------------------- |------------------- |----------:|---------:|---------:|
| ShuffleList  | .NET 6.0           | .NET 6.0           |  93.59 ms | 1.476 ms | 1.233 ms |
| ShuffleArray | .NET 6.0           | .NET 6.0           |  89.88 ms | 1.224 ms | 1.085 ms |
| ShuffleList  | .NET 8.0           | .NET 8.0           |  52.50 ms | 0.439 ms | 0.343 ms |
| ShuffleArray | .NET 8.0           | .NET 8.0           |  53.42 ms | 1.051 ms | 1.329 ms |
| ShuffleList  | .NET Framework 4.8 | .NET Framework 4.8 | 243.63 ms | 2.525 ms | 2.109 ms |
| ShuffleArray | .NET Framework 4.8 | .NET Framework 4.8 |  88.02 ms | 1.710 ms | 2.035 ms |